### PR TITLE
Updated the python regex to account for lines with multiple strings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,7 @@ const imgSrcRecognizer: ImagePathRecognizer = {
 
 const pythonRecognizer : ImagePathRecognizer = {
   recognize: (editor, line) => {
-    let imageUrls: RegExp = /['"]{1}(.*\.[\w]{3})['"]{1}/igm;
+    let imageUrls: RegExp = /['"]{1}([^'"]+\.[\w]{3})['"]{1}/igm;
     let match = imageUrls.exec(line);
     let imagePath: string
 


### PR DESCRIPTION
## Overview
While using the new feature I noticed a bug where lines that had multiple strings wouldn't display images so I tuned the regex to fix the issue. The line below is an example of a case that would fail to produce an image.

## Example
```python
Pattern("This is the description", 95, "image.png")
```