### PR TITLE
Add possibility to turn off underline for recognized URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,19 +31,24 @@
       "type": "object",
       "title": "Image Preview configuration",
       "properties": {
-        "gutterpreview.sourcefolder": {
+        "gutterpreview.sourceFolder": {
           "default": "src",
           "description": "Additional folder to consider when resolving relative urls",
           "type": "string"
         },
-        "gutterpreview.imagepreviewmaxheight": {
+        "gutterpreview.imagePreviewMaxHeight": {
           "default": "100",
           "description": "The maximum height of the image preview",
           "type": "number"
         },
-        "gutterpreview.showimagepreviewongutter": {
+        "gutterpreview.showImagePreviewOnGutter": {
           "default": true,
-          "description": "A flag which indicates wether the image preview should be shown on the gutter",
+          "description": "A flag which indicates whether the image preview should be shown on the gutter",
+          "type": "boolean"
+        },
+        "gutterpreview.showUnderline": {
+          "default": true,
+          "description": "A flag which indicates whether to underline recognized URLs",
           "type": "boolean"
         }
       }

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -46,6 +46,7 @@ export function imageDecorator(
 
         const uri = imageInfo.imagePath;
         const absoluteImagePath = imageInfo.originalImagePath;
+        const underlineEnabled = vscode.workspace.getConfiguration('gutterpreview').get('showUnderline', true);
 
         var range = client.protocol2CodeConverter.asRange(imageInfo.range);
         decorations.push({
@@ -56,7 +57,7 @@ export function imageDecorator(
         let decorationRenderOptions: vscode.DecorationRenderOptions = {
             gutterIconPath: uri,
             gutterIconSize: 'contain',
-            textDecoration: 'underline'
+            textDecoration: underlineEnabled ? 'underline' : 'none'
         };
         let textEditorDecorationType: vscode.TextEditorDecorationType = vscode.window.createTextEditorDecorationType(
             decorationRenderOptions
@@ -74,7 +75,7 @@ export function imageDecorator(
 
     let hoverProvider = {
         provideHover(document: vscode.TextDocument, position: vscode.Position): Thenable<vscode.Hover> {
-            let maxHeight = vscode.workspace.getConfiguration('gutterpreview').get('imagepreviewmaxheight', 100);
+            let maxHeight = vscode.workspace.getConfiguration('gutterpreview').get('imagePreviewMaxHeight', 100);
             if (maxHeight < 0) {
                 maxHeight = 100;
             }
@@ -137,7 +138,7 @@ export function imageDecorator(
         const editors = findEditorsForDocument(document);
         if (editors.length > 0) {
             const config = vscode.workspace.getConfiguration('gutterpreview');
-            const showImagePreviewOnGutter = config.get('showimagepreviewongutter', true);
+            const showImagePreviewOnGutter = config.get('showImagePreviewOnGutter', true);
 
             decoratorProvider(document).then(symbolResponse => {
                 const scanResult = getDocumentDecorators(document);


### PR DESCRIPTION
Hey there, thanks for the great extension! :)

I have added a setting to turn on/off (default is "on") the underline that appears under recognized URLs.

I personally don't like my text underlined, as I think it gives image imports way more importance than they deserve when skimming through the code, so I thought it would be nice to turn them off.

PS: I also changed the case for the existing options to camelCase, which seems to be the standard for extensions. Revert these changes as you like.