### PR TITLE
Support for paths with spaces

### DIFF
--- a/src/recognizers/index.ts
+++ b/src/recognizers/index.ts
@@ -3,10 +3,12 @@ import { linkRecognizer } from './linkrecognizer';
 import { localLinkRecognizer } from './locallinkrecognizer';
 import { dataUrlRecognizer } from './dataurlrecognizer';
 import { siblingRecognizer } from './siblingrecognizer';
+import { markedLinkRecognizer } from './markedlinkrecognizer';
 
 export const recognizers: ImagePathRecognizer[] = [
+    markedLinkRecognizer,
     dataUrlRecognizer,
     linkRecognizer,
     localLinkRecognizer,
-    siblingRecognizer
+    siblingRecognizer,
 ];

--- a/src/recognizers/markedlinkrecognizer.ts
+++ b/src/recognizers/markedlinkrecognizer.ts
@@ -7,8 +7,8 @@ export const markedLinkRecognizer: ImagePathRecognizer = {
         const result = [];
         while ((match = pattern.exec(line))) {
             if (match.length > 0) {
-                const imagePath = match[1];
-                const matchIndex = match.index + match[0].length + 1;
+                const imagePath = match[2];
+                const matchIndex = match.index + match[1].length + 1;
                 result.push({
                     url: imagePath,
                     lineIndex,

--- a/src/recognizers/markedlinkrecognizer.ts
+++ b/src/recognizers/markedlinkrecognizer.ts
@@ -1,0 +1,22 @@
+import { ImagePathRecognizer, UrlMatch } from './recognizer';
+
+export const markedLinkRecognizer: ImagePathRecognizer = {
+    recognize: (lineIndex: number, line: string): UrlMatch[] => {
+        let pattern: RegExp = /preview\((.*?)\)/gi;
+        let match: RegExpExecArray;
+        const result = [];
+        while ((match = pattern.exec(line))) {
+            if (match.length > 0) {
+                const imagePath = match[1];
+                const matchIndex = match.index + 'preview('.length;
+                result.push({
+                    url: imagePath,
+                    lineIndex,
+                    start: matchIndex,
+                    end: matchIndex + imagePath.length
+                });
+            }
+        }
+        return result;
+    }
+};

--- a/src/recognizers/markedlinkrecognizer.ts
+++ b/src/recognizers/markedlinkrecognizer.ts
@@ -2,13 +2,13 @@ import { ImagePathRecognizer, UrlMatch } from './recognizer';
 
 export const markedLinkRecognizer: ImagePathRecognizer = {
     recognize: (lineIndex: number, line: string): UrlMatch[] => {
-        let pattern: RegExp = /preview\((.*?)\)/gi;
+        let pattern: RegExp = /(\[.*?\])\((.*?)\)/gi;
         let match: RegExpExecArray;
         const result = [];
         while ((match = pattern.exec(line))) {
             if (match.length > 0) {
                 const imagePath = match[1];
-                const matchIndex = match.index + 'preview('.length;
+                const matchIndex = match.index + match[0].length + 1;
                 result.push({
                     url: imagePath,
                     lineIndex,


### PR DESCRIPTION
I added `markedLinkRecognizer`. Syntax is markdown like:

```
[any text](/path to image with spaces here.png)
```