### PR TITLE
Support file size description on the hover preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Shows image preview in the gutter and on hover
 [Direct link to Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kisstkondoros.vscode-gutter-preview)
 
 ### Change Log
-
+-   0.28.0
+    -   Add file size to hover preview
+    -   Reorver lines in preview
+    -   Update changelog
 -   0.27.1
     -   Update changelog
 -   0.27.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -614,6 +614,11 @@
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
     },
+    "filesize": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.3.tgz",
+      "integrity": "sha512-UrhwVdUWmP0Jo9uLhVro8U36D4Yp3uT6pfXeNJHVRwyQrZjsqfnypOLthfnuB/bk1glUu7aIY947kyfoOfXuog=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "webpack-cli": "^4.5.0"
   },
   "dependencies": {
+    "filesize": "^8.0.3",
     "image-size": "^0.9.4",
     "slash": "^3.0.0",
     "tmp": "^0.2.1",

--- a/src/util/fileutil.ts
+++ b/src/util/fileutil.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import fileSize from 'filesize';
 
 export function copyFile(source, target, cb) {
     var cbCalled = false;
@@ -22,4 +23,24 @@ export function copyFile(source, target, cb) {
             cbCalled = true;
         }
     }
+}
+
+export function getFilesize(source: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        fs.stat(source,(err, info) => {
+            if (err) {
+                return reject(err);
+            }
+
+            return resolve(fileSize(info.size));
+        });
+    });
+}
+
+export function isLocalFile(source: string): boolean{
+    return source.indexOf('://') == -1;
+}
+
+export function isUrlEncodedFile(path: string): boolean {
+    return path.startsWith('data:image');
 }


### PR DESCRIPTION
One small tweak and one feature has been made.

Feature:
Added line with a file size information.
![image](https://user-images.githubusercontent.com/914429/136690872-be0fa8dd-3b45-4a9b-aa17-d404c1257e3d.png)

Fix:
Meta information moved before the image. I did so because there is no any options to specify width in syntax supported by vscode markdown parser and sometimes it can be difficult to scroll down to meta info.