### PR TITLE
Update regex for data urls

### DIFF
--- a/src/recognizers/dataurlrecognizer.ts
+++ b/src/recognizers/dataurlrecognizer.ts
@@ -2,32 +2,18 @@ import { ImagePathRecognizer, UrlMatch } from './recognizer';
 
 export const dataUrlRecognizer: ImagePathRecognizer = {
     recognize: (lineIndex: number, line: string): UrlMatch[] => {
-        const urlPrefixLength = "url('".length;
-
-        let patternWithSingleQuote: RegExp = /url\(\'(data:image.*)\'\)/gim;
-        let patternWithDoubleQuote: RegExp = /url\(\"(data:image.*)\"\)/gim;
+        const pattern = /data:[^'")]+/gm;
 
         let match: RegExpExecArray;
         const result = [];
-        while ((match = patternWithSingleQuote.exec(line))) {
-            if (match.length > 1) {
-                const imagePath = match[1];
+        while ((match = pattern.exec(line))) {
+            if (match) {
+                const imagePath = match[0];
                 result.push({
                     url: imagePath,
                     lineIndex,
-                    start: match.index + urlPrefixLength,
-                    end: match.index + urlPrefixLength + imagePath.length,
-                });
-            }
-        }
-        while ((match = patternWithDoubleQuote.exec(line))) {
-            if (match.length > 1) {
-                const imagePath = match[1];
-                result.push({
-                    url: imagePath,
-                    lineIndex,
-                    start: match.index + urlPrefixLength,
-                    end: match.index + urlPrefixLength + imagePath.length,
+                    start: match.index,
+                    end: match.index + imagePath.length,
                 });
             }
         }


### PR DESCRIPTION
Make the regex for data urls simpler and work outside of CSS files. Since `'")` all have to be escaped in a data url, we can use that as an easy way to detect when it has terminated.

## Test Plan

**testfiles/test.css**

```css
.foo {
    background: url('data:image/webp;base64,UklGRigAAABXRUJQVlA4TBwAAAAvDoADEA8QEfMfQkEAMkw0zYjOboaI/of1gWN9');
}
```

![image](https://user-images.githubusercontent.com/897931/151993016-d50cfccf-b33a-490f-9e16-1d3dddd1a306.png)


**testfiles/test.js**

```css
var _ = {
    url: 'data:image/webp;base64,UklGRigAAABXRUJQVlA4TBwAAAAvCoACEA8QEfMfQlHbNtCz8Av53DhE9D+Ey6MH',
};
```

![image](https://user-images.githubusercontent.com/897931/151992970-719c696b-7d21-4d6f-8002-cd925254d432.png)
