### PR TITLE
fix: path aliases defined by js/tsconfig don't work on windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,7 @@ const loadPathsFromTSConfig = (
                     if (element.endsWith('*')) {
                         element = element.substring(0, element.length - 1);
                     }
-                    resolvedMapping.push(path.join(baseUrl, element));
+                    resolvedMapping.push(path.join(baseUrl, element).replace(/\\/g, '/'));
                 });
                 paths[aliasWithoutWildcard] = resolvedMapping;
             }

--- a/src/mappers/relativetoworkspacerootmapper.ts
+++ b/src/mappers/relativetoworkspacerootmapper.ts
@@ -16,7 +16,7 @@ class RelativeToWorkspaceRootFileUrlMapper implements AbsoluteUrlMapper {
 
         if (this.workspaceFolder) {
             let rootPath = path.normalize(this.workspaceFolder);
-            const pathName = path.normalize(imagePath);
+            const pathName = path.normalize(imagePath).replace(/\\/g, '/');
             if (pathName) {
                 const pathsToTest = [pathName];
                 if (this.paths['']) {


### PR DESCRIPTION
It works on my device.
Seems to fix #98.