### PR TITLE
Supports detection of some image URLs without extension name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 .vscode-test
 testfiles
+*.vsix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1179,6 +1179,11 @@
         "resolve": "^1.9.0"
       }
     },
+    "regex-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.0.tgz",
+      "integrity": "sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg=="
+    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,12 @@
           "scope": "resource",
           "description": "A flag which indicates whether resources should be resolved from references",
           "type": "boolean"
+        },
+        "gutterpreview.urlDetectionPatterns": {
+          "default": [],
+          "scope": "resource",
+          "markdownDescription": "Sometimes image URLs without extensions (such as `https://example.com/pic/640?fmt=jpeg`) are not detected. You can now specify regular expressions to detect these URLs. configured values (such as `/^http(s)*://example.com/pic/i`) will be parsed using [regex-parser](https://github.com/IonicaBizau/regex-parser.js) and ignored if they are illegal regular expression strings.",
+          "type": "array"
         }
       }
     }
@@ -106,6 +112,7 @@
     "filesize": "^8.0.3",
     "image-size": "^1.0.1",
     "node-fetch": "^2.6.7",
+    "regex-parser": "^2.3.0",
     "slash": "^3.0.0",
     "tmp": "^0.2.1",
     "typescript": "^4.2.3",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { loadConfig } from 'tsconfig-paths/lib/config-loader';
 
 import {
@@ -220,5 +221,12 @@ export function activate(context: ExtensionContext) {
                 };
             });
     };
+
+    vscode.workspace.onDidChangeConfiguration((event) => {
+        if (event.affectsConfiguration('gutterpreview.urlDetectionPatterns')) {
+            imageDecorator(symbolUpdater, context, client);
+        }
+    });
+
     imageDecorator(symbolUpdater, context, client);
 }

--- a/src/util/imagecache.ts
+++ b/src/util/imagecache.ts
@@ -48,7 +48,7 @@ export const ImageCache = {
                 }
                 const tempFile = tmp.fileSync({
                     tmpdir: storagePath,
-                    postfix: absoluteImageUrl.path ? path.parse(absoluteImageUrl.path).ext : 'png',
+                    postfix: absoluteImageUrl.path ? path.parse(absoluteImageUrl.path).ext : '.png',
                 });
                 const filePath = tempFile.name;
                 const promise = new Promise<string>((resolve, reject) => {

--- a/src/util/stringutil.ts
+++ b/src/util/stringutil.ts
@@ -1,3 +1,7 @@
 export const nonNullOrEmpty = (item: string) => {
     return item != null && item.trim().length > 0;
 };
+
+export const nonHttpOnly = (item: string) => {
+    return !['http', 'https'].includes(item);
+};


### PR DESCRIPTION
This PR originated from #155.

During use, I found that some pictures could not be preview (such as https://mmbiz.qpic.cn/mmbiz_jpg/Tf57CQjDpibn2Qx0soyYTPRCGMWSJ2AHYasuUpLf5o7TvibD9HTxOjibT0Y0LbiaCO6mIsrAibEXZiacBBDnfzZB8OLw/640?wx_fmt=jpeg). Since it is a link with Referer anti-hotlink protection, it cannot be displayed on third-party websites. Therefore, it is mistakenly believed that the request contains HTTP Referer, resulting in the inability to access the image.

However, after verification, it was found that after a series of parsed links, the extension name could not be obtained. It is ignored because it is not within the scope of `acceptedExtensions`.

```ts
// server.ts
async function convertToLocalImagePath(absoluteImagePath: string, urlMatch: UrlMatch): Promise<ImageInfo> {
    if (absoluteImagePath) {
        let isDataUri = absoluteImagePath.indexOf('data:image') == 0;
        let isExtensionSupported: boolean;

        if (!isDataUri) {
            const absoluteImageUrl = URI.parse(absoluteImagePath);
            if (absoluteImageUrl && absoluteImageUrl.path) {
                let absolutePath = path.parse(absoluteImageUrl.path);
                isExtensionSupported = acceptedExtensions.some(
                    (ext) => absolutePath && absolutePath.ext && absolutePath.ext.toLowerCase().startsWith(ext)
                );
            }
        }

        const start = Position.create(urlMatch.lineIndex, urlMatch.start);
        const end = Position.create(urlMatch.lineIndex, urlMatch.end);
        const range = { start, end };

        absoluteImagePath = absoluteImagePath.replace(/\|(width=\d*)?(height=\d*)?/gm, '');

        if (isDataUri || isExtensionSupported) {
            // ...
        }
    }
}
```

> [url parse demo](https://runkit.com/tofrankie/gutter-preview-url-parse)

I think detecting URL extensions is a reasonable and correct approach since there are a lot of non-image URLs in many projects and it can reduce a lot of unnecessary requests.

However, some OSS services do provide image links that do not end with a common extension name, so we hope to add a configuration item `gutterpreview.urlDetectionPatterns`, which allows you to set some regular expressions. When the extension does not meet the requirements, a specific regular expression can be matched so that the image can be obtained normally.

The configuration example is as follows:

```json
{
  "gutterpreview.urlDetectionPatterns": ["/^http(s)*://mmbiz.qpic.cn/i"]
}
```

