### PR TITLE
Automatically add file extensions when saving locally

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceRoot}", "${workspaceFolder}/testfiles"],
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--disable-extensions", "${workspaceFolder}/testfiles"],
       "sourceMaps": true,
     },
     {

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Shows image preview in the gutter and on hover
 
 [Direct link to Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kisstkondoros.vscode-gutter-preview)
 
-### Change Log
+## Change Log
 
+-   0.32.3
+    -   Fix issues where images might not be displayed (contribution by @tofrankie)
 -   0.32.2
     -   Update changelog
     -   Support slash "/" in aliases
@@ -258,6 +260,6 @@ Shows image preview in the gutter and on hover
 -   0.0.1
     -   Initial project setup
 
-### License
+## License
 
 Licensed under MIT

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Shows image preview in the gutter and on hover
 -   0.31.0
     -   Update changelog
     -   Add `avif` support (contribution by @rommelmamedov)
-    -   Add option to load images without extensions (contribution by @toFrankie)
+    -   Add option to load images without extensions (contribution by @tofrankie)
         -   See option "gutterpreview.urlDetectionPatterns" for details
 -   0.30.0
     -   Update changelog

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-gutter-preview",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-gutter-preview",
-      "version": "0.32.2",
+      "version": "0.32.3",
       "license": "MIT",
       "devDependencies": {
         "@types/mime-types": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.32.2",
       "license": "MIT",
       "devDependencies": {
+        "@types/mime-types": "^3.0.1",
         "@types/node": "^20.12.8",
         "@types/node-fetch": "^2.6.11",
         "@types/tmp": "^0.2.6",
@@ -17,6 +18,7 @@
         "husky": "^9.0.11",
         "image-size": "^1.1.1",
         "json5": "^2.2.3",
+        "mime-types": "^3.0.2",
         "node-fetch": "^3.3.2",
         "prettier": "^3.2.5",
         "regex-parser": "^2.3.0",
@@ -726,6 +728,13 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "node_modules/@types/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.12.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
@@ -1186,6 +1195,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -1538,24 +1570,30 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "mime-db": "1.46.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Tamas Kiss",
   "publisher": "kisstkondoros",
   "license": "MIT",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "displayName": "Image preview",
   "icon": "images/logo.png",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "vscode:prepublish": "npm run build"
   },
   "devDependencies": {
+    "@types/mime-types": "^3.0.1",
     "@types/node": "^20.12.8",
     "@types/node-fetch": "^2.6.11",
     "@types/tmp": "^0.2.6",
@@ -112,6 +113,7 @@
     "husky": "^9.0.11",
     "image-size": "^1.1.1",
     "json5": "^2.2.3",
+    "mime-types": "^3.0.2",
     "node-fetch": "^3.3.2",
     "prettier": "^3.2.5",
     "regex-parser": "^2.3.0",

--- a/src/util/imagecache.ts
+++ b/src/util/imagecache.ts
@@ -4,6 +4,7 @@ import fetch from 'node-fetch';
 import * as path from 'path';
 import * as url from 'url';
 import * as fs from 'fs';
+import * as mime from 'mime-types';
 import { copyFile } from './fileutil';
 import { replaceCurrentColorInFileContent } from './currentColorHelper';
 
@@ -46,11 +47,9 @@ export const ImageCache = {
                 if (!fs.existsSync(storagePath)) {
                     fs.mkdirSync(storagePath);
                 }
-                const tempFile = tmp.fileSync({
-                    tmpdir: storagePath,
-                    postfix: absoluteImageUrl.path ? path.parse(absoluteImageUrl.path).ext : '.png',
-                });
-                const filePath = tempFile.name;
+
+                const urlExt = absoluteImageUrl.path ? path.parse(absoluteImageUrl.path).ext : '';
+
                 const promise = new Promise<string>((resolve, reject) => {
                     if (absoluteImageUrl.scheme && absoluteImageUrl.scheme.startsWith('http')) {
                         fetch(new url.URL(absoluteImagePath).toString(), {
@@ -61,24 +60,48 @@ export const ImageCache = {
                                     reject(resp.statusText);
                                     return;
                                 }
+
+                                let tempFile: tmp.FileResult;
+
+                                if (urlExt) {
+                                    tempFile = tmp.fileSync({
+                                        tmpdir: storagePath,
+                                        postfix: urlExt,
+                                    });
+                                } else {
+                                    const contentType = resp.headers.get('content-type') || '';
+                                    const inferredExt = contentType ? mime.extension(contentType) : false;
+
+                                    tempFile = tmp.fileSync({
+                                        tmpdir: storagePath,
+                                        postfix: inferredExt ? `.${inferredExt}` : '',
+                                    });
+                                }
+
+                                const filePath = tempFile.name;
+
                                 const dest = fs.createWriteStream(filePath);
                                 resp.body.pipe(dest);
-                                resp.body.on('error', (err) => {
-                                    reject(err);
-                                });
-                                dest.on('finish', function () {
-                                    resolve(filePath);
-                                });
+                                resp.body.on('error', (err) => reject(err));
+                                dest.on('finish', () => resolve(filePath));
                             })
                             .catch((err) => reject(err));
                     } else {
+                        const tempFile = tmp.fileSync({
+                            tmpdir: storagePath,
+                            postfix: urlExt || '.png',
+                        });
+
+                        const filePath = tempFile.name;
+
                         try {
                             const handle = fs.watch(absoluteImagePath, function fileChangeListener() {
                                 handle.close();
                                 fs.unlink(filePath, () => {});
                                 ImageCache.delete(absoluteImagePath);
                             });
-                        } catch (e) {}
+                        } catch {}
+
                         copyFile(absoluteImagePath, filePath, (err) => {
                             if (!err) {
                                 resolve(filePath);


### PR DESCRIPTION
## Problem Description

Now I have an image link (the response is actually a `.svg` image):

```text
https://img.shields.io/npm/v/@tofrankie/eslint
```

My configuration is:

```json
{
  "gutterpreview.urlDetectionPatterns": ["/^https://img.shields.io/i"]
}
```

Since it matches the detection rule, it gets downloaded locally, for example:

```text
/Users/frankie/Library/Application Support/Code/User/workspaceStorage/21082d848e28dd7c258e3bc289ce3fa3/kisstkondoros.vscode-gutter-preview/tmp-17276-S8tNZy52AueJ
```

But it cannot be displayed in VS Code (see below).  

<img width="1146" height="272" alt="image" src="https://github.com/user-attachments/assets/e2a0a6aa-1a9b-4b61-b804-d3fb4796a87e" />

**The likely reason is**: the file itself has no extension.

## What This PR Does

For `http(s)` URLs: if the URL parsed from the source file does not include an extension, this change attempts to infer the extension from the `Content-Type`, and then uses that inferred extension as the temporary file's extension.

<img width="1061" height="330" alt="image" src="https://github.com/user-attachments/assets/a32084ef-faa2-4aeb-a5a5-154364a96ebd" />

Other changes:

1. Added the `--disable-extensions` argument so the extension development host loads no extensions, avoiding interference with tests.
2. Updated my GitHub username. #162